### PR TITLE
Update Cargo.toml to version 1.6.5

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -5889,7 +5889,7 @@ dependencies = [
 
 [[package]]
 name = "sdf-viewer"
-version = "1.6.5-alpha.10"
+version = "1.6.5"
 dependencies = [
  "android_logger",
  "anyhow",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "sdf-viewer"
-version = "1.6.5-alpha.10"
+version = "1.6.5"
 authors = ["Yeicor"]
 description = "SDF Viewer"
 repository = "https://github.com/Yeicor/sdf-viewer"


### PR DESCRIPTION
This PR updates the version in Cargo.toml to 1.6.5 and moves the release tag to the commit.