### PR TITLE
Update Cargo.toml to version 1.6.7

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -6014,7 +6014,7 @@ dependencies = [
 
 [[package]]
 name = "sdf-viewer"
-version = "1.6.6"
+version = "1.6.7"
 dependencies = [
  "android_logger",
  "anyhow",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "sdf-viewer"
-version = "1.6.6"
+version = "1.6.7"
 authors = ["Yeicor"]
 description = "SDF Viewer"
 repository = "https://github.com/Yeicor/sdf-viewer"


### PR DESCRIPTION
This PR updates the version in Cargo.toml to 1.6.7 and moves the release tag to the commit.